### PR TITLE
[BUGFIX] add missing extension key in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,5 +33,10 @@
 		"one-time",
 		"password",
 		"backend"
-	]
+	],
+	"extra": {
+		"typo3/cms": {
+		    "extension-key": "defbu_authenticator"
+		}
+    	},
 }


### PR DESCRIPTION
Use proper extension folder in composer mode.